### PR TITLE
chore: dev-tooling fixes (dev TLS, crypto RNG, eslint dist ignore)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import sonarjs from 'eslint-plugin-sonarjs';
                                                                                                    
 export default tseslint.config(
     // Ignore generated type definitions and build artifacts
-    {ignores: ['**/node_modules/**', '**/@girs/**', 'build/**']},
+    {ignores: ['**/node_modules/**', '**/@girs/**', 'build/**', 'dist/**']},
 
     eslint.configs.recommended,
     ...tseslint.configs.recommended,

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -8,6 +8,14 @@
 {
   default = pkgs.mkShell {
     LD_PRELOAD = "${pkgs.gtk4-layer-shell}/lib/libgtk4-layer-shell.so";
+
+    # glib-networking's GIO module dir is not propagated into the dev shell
+    # environment, which leaves libsoup without a TLS backend and breaks
+    # HTTPS requests (e.g. GWeather's met.no provider) in dev mode.
+    shellHook = ''
+      export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules''${GIO_EXTRA_MODULES:+:$GIO_EXTRA_MODULES}"
+    '';
+
     packages =
       nativeBuildInputs
       ++ buildInputs

--- a/src/lib/services/clipboard/cryptoEngineTables.ts
+++ b/src/lib/services/clipboard/cryptoEngineTables.ts
@@ -1,3 +1,5 @@
+import Gio from 'gi://Gio?version=2.0';
+
 // ── AES-256 constants ───────────────────────────────────────────────────────
 
 export const BLOCK_SIZE = 16; // 128 bits
@@ -53,11 +55,15 @@ export function xtime(a: number): number {
     return ((a << 1) ^ (((a >>> 7) & 1) * 0x1b)) & 0xff;
 }
 
-/** Generate cryptographically random bytes using Math.random (GJS fallback). */
+/** Generate cryptographically random bytes from /dev/urandom. */
 export function getRandomBytes(count: number): Uint8Array {
-    const bytes = new Uint8Array(count);
-    for (let i = 0; i < count; i++) bytes[i] = Math.floor(Math.random() * 256);
-    return bytes;
+    const stream = Gio.File.new_for_path('/dev/urandom').read(null);
+    try {
+        const bytes = stream.read_bytes(count, null);
+        return new Uint8Array(bytes.toArray());
+    } finally {
+        stream.close(null);
+    }
 }
 
 /** Pad data to a multiple of 16 bytes with zeros. */


### PR DESCRIPTION
## What Changed

Three small, independent fixes split out of the gnim v2 migration branch — none of them depend on the migration:

1. **`fix:` dev shell TLS** — the dev shell's `GIO_EXTRA_MODULES` only carried gvfs + dconf, so `GTlsBackend` was unavailable and all libsoup HTTPS failed with `TLS support is not available` (e.g. GWeather MET_NO updates silently never became valid in dev mode). Production was unaffected (wrapGAppsHook4 collects GIO modules at wrap time).
2. **`security:` clipboard crypto RNG** — `getRandomBytes` generated AES keys and nonces with `Math.random()` (not a CSPRNG). Now reads `/dev/urandom` via Gio.
3. **`chore:` eslint ignores `dist/`** — `dist/` is gitignored compiled output; linting it produced hundreds of phantom errors.

## Why

These stand alone on `main` and can merge immediately, shrinking the migration PR's surface.

## Risk Score

**1/5**

- 3 files, ~25 lines; no behavior changes in production code paths except crypto RNG source (strictly stronger)
- Dev-shell change affects dev environment only

## Type

- [x] fix / security / chore

## Test Results

| Scenario | Status |
|----------|--------|
| `eslint` repo-wide | ✅ 0 errors |
| `tsc --noEmit` | ⚠️ 2 pre-existing errors on `main` in untouched `windowswitcher` (not introduced here) |
| Dev runtime: GWeather temperature displays | ✅ manually verified with this fix |
| Clipboard crypto (nonce/key paths) | ✅ exercised by clipboard test suite on the migration branch |

## Checklist

- [x] Tests pass (n/a — no test suite changes)
- [x] Lint passes
- [x] Type-check passes (pre-existing main breakage unrelated)
- [x] Manual testing done
- [x] Risk score self-assessed
