### PR TITLE
chore: post-migration lint and dead-code cleanup

### DIFF
--- a/src/apps/share-picker/main.ts
+++ b/src/apps/share-picker/main.ts
@@ -29,7 +29,6 @@ import {
     windowAddr,
     runCapture,
     loadTexture,
-    captureMonitor,
     captureMonitorSync,
     captureWindow,
 } from './capture';
@@ -98,10 +97,10 @@ function main() {
             );
         }
         for (const w of windows) {
-            logger.info(
-                CAT,
-                `  window: ${w.info.clazz} geo=${w.geometry ? `${w.geometry.width}x${w.geometry.height}` : 'none'}`
-            );
+            const geo = w.geometry
+                ? `${w.geometry.width}x${w.geometry.height}`
+                : 'none';
+            logger.info(CAT, `  window: ${w.info.clazz} geo=${geo}`);
         }
 
         applyPopupCss();

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -17,13 +17,3 @@ declare module 'gi://GTop' {
         path: string
     ): void;
 }
-
-// AstalWl.WlDisplay is not included in the GIR type definitions.
-declare module 'gi://AstalWl?version=0.1' {
-    interface WlDisplay {
-        // wayland-native display — no additional methods needed
-    }
-    var WlDisplay: {
-        get_default(): WlDisplay;
-    };
-}

--- a/src/lib/core/eventBus.ts
+++ b/src/lib/core/eventBus.ts
@@ -44,7 +44,7 @@ export interface EventMap {
 type Unsubscribe = () => void;
 
 class EventBus {
-    #listeners = new Map<string, Set<Function>>();
+    #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     on<K extends keyof EventMap>(
         event: K,
@@ -54,9 +54,11 @@ class EventBus {
         if (!this.#listeners.has(key)) {
             this.#listeners.set(key, new Set());
         }
-        (this.#listeners.get(key) as Set<Function>).add(fn);
+        this.#listeners.get(key)!.add(fn as (...args: unknown[]) => void);
         return () => {
-            this.#listeners.get(key)?.delete(fn);
+            this.#listeners
+                .get(key)
+                ?.delete(fn as (...args: unknown[]) => void);
         };
     }
 
@@ -68,7 +70,7 @@ class EventBus {
         const fns = this.#listeners.get(key);
         if (!fns) return;
         for (const fn of fns) {
-            (fn as (...args: any[]) => void)(...args);
+            fn(...(args as unknown[]));
         }
     }
 

--- a/src/lib/core/file.ts
+++ b/src/lib/core/file.ts
@@ -2,6 +2,9 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import logger from './logger';
 
+// Keeps Gio.FileMonitor instances alive so GJS doesn't GC them while
+// monitoring (monitors must stay referenced to keep delivering events).
+// eslint-disable-next-line sonarjs/no-unused-collection
 const monitorFiles = new Set<Gio.FileMonitor>();
 
 export function readFile(file: string | Gio.File) {

--- a/src/lib/core/process.ts
+++ b/src/lib/core/process.ts
@@ -1,6 +1,5 @@
 import Gio from 'gi://Gio?version=2.0';
 import GLib from 'gi://GLib?version=2.0';
-import GObject from 'gi://GObject?version=2.0';
 import {
     Object,
     register,

--- a/src/lib/core/shellBus.ts
+++ b/src/lib/core/shellBus.ts
@@ -72,10 +72,13 @@ export default class ShellBus extends Object {
             ? () => void
             : (payload: ShellEventPayloads[E]) => void
     ): number {
-        return GObject.signal_connect(this, event, (_source: GObject.Object, ...args: unknown[]) => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-arguments
-            (fn as (...args: unknown[]) => void)(...args);
-        });
+        return GObject.signal_connect(
+            this,
+            event,
+            (_source: GObject.Object, ...args: unknown[]) => {
+                (fn as (...args: unknown[]) => void)(...args);
+            }
+        );
     }
 
     /** Remove a listener by handler ID. */

--- a/src/lib/services/capture/recordTargets.ts
+++ b/src/lib/services/capture/recordTargets.ts
@@ -1,4 +1,3 @@
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../hyprland';
 import logger from '../../core/logger';
 import {notify} from './utils';

--- a/src/lib/services/capture/recorder.ts
+++ b/src/lib/services/capture/recorder.ts
@@ -1,4 +1,3 @@
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../hyprland';
 import GLib from 'gi://GLib?version=2.0';
 import logger from '../../core/logger';

--- a/src/lib/services/capture/stage.ts
+++ b/src/lib/services/capture/stage.ts
@@ -1,5 +1,4 @@
 import Gdk from 'gi://Gdk?version=4.0';
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../hyprland';
 import GLib from 'gi://GLib?version=2.0';
 import Gio from 'gi://Gio?version=2.0';

--- a/src/lib/services/monitoring/monitors.ts
+++ b/src/lib/services/monitoring/monitors.ts
@@ -1,7 +1,7 @@
 /**
  * Monitor Service — Wayland-native monitor tracking via AstalWl.
  *
- * Uses AstalWl.WlDisplay for monitor enumeration and hotplug detection
+ * Uses AstalWl.Registry for monitor enumeration and hotplug detection
  * instead of Gdk.Monitor. This gives us:
  *   - Reliable connector names (no fallback chain needed)
  *   - Fires at the Wayland protocol level (before Gdk/Hyprland)
@@ -31,7 +31,9 @@ import logger from '../../core/logger';
  *
  * Falls back to description matching and then to geometry matching.
  */
-const Gdk2HyprMonitor = (GMonitor: Gdk.Monitor): AstalHyprland.Monitor | null => {
+const Gdk2HyprMonitor = (
+    GMonitor: Gdk.Monitor
+): AstalHyprland.Monitor | null => {
     const hyprland = getHyprland();
     if (!hyprland) return null;
 
@@ -189,7 +191,7 @@ class MonitorService extends Object {
         this.#wlSignalIds = [
             this.#wlDisplay.connect(
                 'output-added',
-                (_wl: any, output: AstalWl.Output) => {
+                (_wl: AstalWl.Registry, output: AstalWl.Output) => {
                     const gdkMon = gdkMonitorByConnector(output.name);
                     if (gdkMon) {
                         this.#addMonitor(gdkMon);
@@ -202,7 +204,7 @@ class MonitorService extends Object {
 
             this.#wlDisplay.connect(
                 'output-removed',
-                (_wl: any, output: AstalWl.Output) => {
+                (_wl: AstalWl.Registry, output: AstalWl.Output) => {
                     const gdkMon = gdkMonitorByConnector(output.name);
                     if (gdkMon) {
                         this.#removeMonitor(gdkMon);
@@ -252,7 +254,10 @@ class MonitorService extends Object {
         if (hyprland) {
             if (hyprland.get_monitors().length !== this.#monitors.length) {
                 this.#pendingSync = true;
-                logger.debug('monitors', 'Monitor counts differ, deferring notify');
+                logger.debug(
+                    'monitors',
+                    'Monitor counts differ, deferring notify'
+                );
             } else {
                 this.#pendingSync = false;
             }
@@ -267,7 +272,10 @@ class MonitorService extends Object {
         if (hyprland) {
             if (hyprland.get_monitors().length !== this.#monitors.length) {
                 this.#pendingSync = true;
-                logger.debug('monitors', 'Monitor counts differ, deferring notify');
+                logger.debug(
+                    'monitors',
+                    'Monitor counts differ, deferring notify'
+                );
             } else {
                 this.#pendingSync = false;
                 this.notify('monitors');

--- a/src/lib/services/power/hypridle.ts
+++ b/src/lib/services/power/hypridle.ts
@@ -73,6 +73,7 @@ export default class Hypridle extends GObject {
         return this.instance;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     #values: Record<PropKey, any> = {
         enabled: true,
         idleTimeout: 300,
@@ -84,6 +85,7 @@ export default class Hypridle extends GObject {
         suspendEnabled: false,
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     #settings: Record<string, (v: any) => void> | null = null;
     #process: Process | null = null;
 
@@ -152,6 +154,7 @@ export default class Hypridle extends GObject {
 
     // ── Centralised property write ────────────────────────────────────
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     #set(key: PropKey, value: any) {
         const def = PROPS[key];
         if (!def) return;

--- a/src/lib/services/state/requestHandler.ts
+++ b/src/lib/services/state/requestHandler.ts
@@ -40,7 +40,7 @@ function activateWithString(
 
 // ── Build command tree ──
 
-function buildCLI(app: Gio.Application): Quarrel.Command {
+function buildCLI(_app: Gio.Application): Quarrel.Command {
     // Subcommands
     const toggle = new Quarrel.Command({name: 'toggle'})
         .about('Toggle a widget visibility')

--- a/src/widget/applauncher/index.tsx
+++ b/src/widget/applauncher/index.tsx
@@ -1,4 +1,3 @@
-import Hyprland from 'gi://AstalHyprland';
 import {getHyprland} from '../../lib/hyprland';
 import Astal from 'gi://Astal?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';

--- a/src/widget/bar/clock.tsx
+++ b/src/widget/bar/clock.tsx
@@ -1,4 +1,3 @@
-import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
 import {Accessor, For, bind, computed} from 'gnim';
@@ -6,11 +5,10 @@ import Clock from '../../lib/services/time/clock';
 import TimerService from '../../lib/services/time/timerService';
 import {useSettings} from '../../lib/settings';
 import {useStyle} from '../../style/useStyle';
-import {fmtDuration, cityName, fmtOffset} from '../../lib/core/time';
+import {fmtDuration, cityName} from '../../lib/core/time';
 import {TimerSection} from '../quicksettings/timer/TimerSection';
 
 export default ({
-    vertical,
     visible = true,
 }: {
     vertical: Accessor<boolean>;
@@ -22,7 +20,6 @@ export default ({
     });
     const {general} = useSettings();
     const time = Clock.get_default().time;
-    const localTz = GLib.TimeZone.new_local();
     const hour = time.as(t => t.format('%H')!);
     const minute = time.as(t => t.format('%M')!);
 
@@ -46,11 +43,17 @@ export default ({
                     <Gtk.Label label="World Clock" halign={Gtk.Align.CENTER} />
                     <For each={general.timezones}>
                         {(tzId: string) => {
-                            const tz = GLib.TimeZone.new(tzId);
                             return (
                                 <Gtk.Box spacing={8}>
-                                    <Gtk.Label label={cityName(tzId)} hexpand halign={Gtk.Align.START} />
-                                    <Gtk.Label label={tzId} halign={Gtk.Align.END} />
+                                    <Gtk.Label
+                                        label={cityName(tzId)}
+                                        hexpand
+                                        halign={Gtk.Align.START}
+                                    />
+                                    <Gtk.Label
+                                        label={tzId}
+                                        halign={Gtk.Align.END}
+                                    />
                                 </Gtk.Box>
                             );
                         }}
@@ -67,10 +70,7 @@ export default ({
                 valign={Gtk.Align.CENTER}
                 spacing={4}
             >
-                <Gtk.Box
-                    visible={timerActive.as(a => !a)}
-                    spacing={4}
-                >
+                <Gtk.Box visible={timerActive.as(a => !a)} spacing={4}>
                     <Gtk.Label
                         label={hour}
                         cssClasses={['title-1', 'numeric']}

--- a/src/widget/bar/windowTitle.tsx
+++ b/src/widget/bar/windowTitle.tsx
@@ -1,4 +1,3 @@
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../lib/hyprland';
 import Gtk from 'gi://Gtk?version=4.0';
 import Pango from 'gi://Pango?version=1.0';

--- a/src/widget/common/PopupWindow.tsx
+++ b/src/widget/common/PopupWindow.tsx
@@ -22,13 +22,11 @@ import Gtk from 'gi://Gtk?version=4.0';
 import {Accessor, bind, createState, JSX} from 'gnim';
 import {app} from '../../apps/shell/App';
 import {useSettings} from '../../lib/settings';
-import Hyprland from 'gi://AstalHyprland';
 import {getHyprland} from '../../lib/hyprland';
 
 // ── Types ──
 
 const {TOP, BOTTOM, LEFT, RIGHT} = Astal.WindowAnchor;
-type Anchor = number; // bitmask of Astal.WindowAnchor
 
 export interface PopupWindowProps {
     /** Unique window name, used as the Astal namespace. */
@@ -44,7 +42,8 @@ export interface PopupWindowProps {
      * Bar-position-derived anchor or explicit anchor bitmask.
      * Auto-derived from `bar.position` GSetting by default.
      */
-    anchor?: Accessor<Anchor> | Anchor;
+    /** Bitmask of Astal.WindowAnchor. */
+    anchor?: Accessor<number> | number;
 
     /** Astal layer preference. Defaults to OVERLAY. */
     layer?: Astal.Layer;
@@ -93,7 +92,7 @@ export interface PopupHandle {
 const BAR_MARGIN_TOP_BOTTOM = 40;
 const BAR_MARGIN_SIDE = 8;
 
-function defaultAnchor(position: number): Anchor {
+function defaultAnchor(position: number): number {
     if (position === TOP) return TOP | LEFT | RIGHT;
     if (position === RIGHT) return RIGHT | TOP | BOTTOM;
     if (position === BOTTOM) return BOTTOM | LEFT | RIGHT;
@@ -134,7 +133,7 @@ export default (props: PopupWindowProps) => {
     const defaultMon = bind(hyprland, 'focused-monitor').as(m => m.id);
 
     // Resolve anchor
-    let anchorValue: Accessor<Anchor> | Anchor;
+    let anchorValue: Accessor<number> | number;
     if (anchorProp !== undefined) {
         anchorValue = anchorProp;
     } else {

--- a/src/widget/common/iconButton.tsx
+++ b/src/widget/common/iconButton.tsx
@@ -1,5 +1,6 @@
 import Gdk from 'gi://Gdk?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';
+import {JSX} from 'gnim';
 import {usePopoverCleanup} from './popoverCleanup';
 
 interface IconButtonProps {
@@ -21,7 +22,7 @@ export const IconButton = (props: IconButtonProps) => (
 );
 
 interface IconMenuButtonProps extends Omit<IconButtonProps, 'onClicked'> {
-    children?: any;
+    children?: JSX.Element | JSX.Element[];
 }
 
 export const IconMenuButton = (props: IconMenuButtonProps) => (

--- a/src/widget/common/notification.tsx
+++ b/src/widget/common/notification.tsx
@@ -55,7 +55,7 @@ export default ({
     const expireMs =
         notification.expireTimeout > 0 ? notification.expireTimeout : 5000;
     const urgency = notification.urgency;
-    const appName = notification.appName || notification.appName || '';
+    const appName = notification.appName || '';
     const hasImage = !!notification.image;
     const bodyText = notification.body || '';
     const hasActions = notification.actions.length > 0;

--- a/src/widget/greeter/GreetSession.ts
+++ b/src/widget/greeter/GreetSession.ts
@@ -7,6 +7,8 @@
  *   → start_session (on success)
  */
 import Greet from 'gi://AstalGreet';
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
 import {Object, register, property} from 'gnim/gobject';
 import logger from '../../lib/core/logger';
 
@@ -181,19 +183,23 @@ export class GreetSession extends Object {
     startSession(cmd: string[], env: string[] = []): void {
         if (!this.#greeter) return;
 
-        this.#greeter.start_session(cmd, env, (_g: any, res: any) => {
-            try {
-                this.#greeter!.start_session_finish(res);
-                // If start_session returns, the session is running.
-                // The greeter process (this app) should terminate.
-                logger.info('greeter', 'session started successfully');
-                this.#onSessionStarted?.();
-            } catch (e) {
-                this.#errorMessage = `Failed to start session: ${e}`;
-                this.notify('error-message');
-                this.state = 'error';
+        this.#greeter.start_session(
+            cmd,
+            env,
+            (_g: GObject.Object | null, res: Gio.AsyncResult) => {
+                try {
+                    this.#greeter!.start_session_finish(res);
+                    // If start_session returns, the session is running.
+                    // The greeter process (this app) should terminate.
+                    logger.info('greeter', 'session started successfully');
+                    this.#onSessionStarted?.();
+                } catch (e) {
+                    this.#errorMessage = `Failed to start session: ${e}`;
+                    this.notify('error-message');
+                    this.state = 'error';
+                }
             }
-        });
+        );
     }
 
     /**

--- a/src/widget/lockscreen/authPanel.tsx
+++ b/src/widget/lockscreen/authPanel.tsx
@@ -22,7 +22,7 @@ export const LockscreenAuthPanel = ({
     fpStateBinding,
     fpErrorBinding,
 }: AuthPanelProps) => {
-    const [_password, setPassword] = createState('');
+    const [, setPassword] = createState('');
 
     return (
         <Gtk.Box

--- a/src/widget/lockscreen/widgets.tsx
+++ b/src/widget/lockscreen/widgets.tsx
@@ -7,7 +7,7 @@
  */
 
 import Gtk from 'gi://Gtk?version=4.0';
-import {For, bind, createState} from 'gnim';
+import {For, bind, createState, JSX} from 'gnim';
 import MediaController from '../../lib/services/session/mediaController';
 import logger from '../../lib/core/logger';
 
@@ -17,7 +17,7 @@ export interface LockscreenWidgetDef {
     id: string;
     position: 'center' | 'end';
     priority: number;
-    render: () => any;
+    render: () => JSX.Element;
 }
 
 // ── Registry ────────────────────────────────────────────────────

--- a/src/widget/osd/popup.tsx
+++ b/src/widget/osd/popup.tsx
@@ -2,16 +2,16 @@ import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import GLib from 'gi://GLib?version=2.0';
 import {connectFor} from '../../lib/core/connectFor';
+import {JSX} from 'gnim';
 
 const TIMEOUT_MS = 2000;
-
 export default ({
     widget,
     connectable,
     signals,
     revealerRef,
 }: {
-    widget: any;
+    widget: JSX.Element;
     connectable: GObject.Object | null;
     signals: string[];
     revealerRef?: (revealer: Gtk.Revealer) => void;

--- a/src/widget/quicksettings/appMixer.tsx
+++ b/src/widget/quicksettings/appMixer.tsx
@@ -1,5 +1,5 @@
 import Gtk from 'gi://Gtk?version=4.0';
-import {bind, effect, For} from 'gnim';
+import {bind, For} from 'gnim';
 import AudioController from '../../lib/services/audio/audioController';
 import AppMixer from '../../lib/services/audio/mixer';
 import {usePopoverCleanup} from '../common/popoverCleanup';
@@ -53,10 +53,7 @@ export default () => {
                                             cssClasses={['flat']}
                                             halign={Gtk.Align.FILL}
                                             onClicked={() => {
-                                                mixer.setTargetNode(
-                                                    id,
-                                                    -1
-                                                );
+                                                mixer.setTargetNode(id, -1);
                                                 popoverRef?.popdown();
                                             }}
                                         >
@@ -71,12 +68,8 @@ export default () => {
                                         <For each={speakers}>
                                             {speaker => (
                                                 <Gtk.Button
-                                                    cssClasses={[
-                                                        'flat',
-                                                    ]}
-                                                    halign={
-                                                        Gtk.Align.FILL
-                                                    }
+                                                    cssClasses={['flat']}
+                                                    halign={Gtk.Align.FILL}
                                                     // eslint-disable-next-line sonarjs/no-nested-functions
                                                     onClicked={() => {
                                                         mixer.setTargetNode(
@@ -91,17 +84,10 @@ export default () => {
                                                             speaker.description ??
                                                             ''
                                                         }
-                                                        maxWidthChars={
-                                                            25
-                                                        }
+                                                        maxWidthChars={25}
                                                         ellipsize={3}
-                                                        halign={
-                                                            Gtk.Align
-                                                                .START
-                                                        }
-                                                        cssClasses={[
-                                                            'body',
-                                                        ]}
+                                                        halign={Gtk.Align.START}
+                                                        cssClasses={['body']}
                                                     />
                                                 </Gtk.Button>
                                             )}
@@ -163,7 +149,10 @@ export default () => {
                                         widthRequest={100}
                                         adjustment={adjustment}
                                         onValueChanged={self =>
-                                            mixer.setVolume(id, self.get_value())
+                                            mixer.setVolume(
+                                                id,
+                                                self.get_value()
+                                            )
                                         }
                                     />
                                 );

--- a/src/widget/quicksettings/expander/media.tsx
+++ b/src/widget/quicksettings/expander/media.tsx
@@ -72,13 +72,7 @@ const TitleArtist = ({player}: {player: Mpris.Player}) => {
     );
 };
 
-const PlaybackButtons = ({
-    player,
-    slot,
-}: {
-    player: Mpris.Player;
-    slot?: string;
-}) => {
+const PlaybackButtons = ({player}: {player: Mpris.Player; slot?: string}) => {
     const mc = MediaController.get_default();
     return (
         <Gtk.Box>

--- a/src/widget/quicksettings/index.tsx
+++ b/src/widget/quicksettings/index.tsx
@@ -1,4 +1,3 @@
-import Hyprland from 'gi://AstalHyprland';
 import {getHyprland} from '../../lib/hyprland';
 import Astal from 'gi://Astal?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';

--- a/src/widget/quicksettings/network/apRow.tsx
+++ b/src/widget/quicksettings/network/apRow.tsx
@@ -222,11 +222,11 @@ function ApRow({
                         if (isActive()) {
                             try {
                                 wifi.deactivate_connection(null);
-                            } catch (e: any) {
+                            } catch (e) {
                                 logger.error(
                                     'network',
                                     'deactivate failed:',
-                                    e.message
+                                    e instanceof Error ? e.message : String(e)
                                 );
                             }
                             return;

--- a/src/widget/recording-bar/index.tsx
+++ b/src/widget/recording-bar/index.tsx
@@ -1,6 +1,5 @@
 import Astal from 'gi://Astal?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../lib/hyprland';
 import {bind} from 'gnim';
 import {app} from '../../apps/shell/App';

--- a/src/widget/region-selector/index.tsx
+++ b/src/widget/region-selector/index.tsx
@@ -1,7 +1,6 @@
 import Astal from 'gi://Astal?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../lib/hyprland';
 import Cairo from 'gi://cairo?version=1.0';
 import {bind, createState} from 'gnim';

--- a/src/widget/screenshot-ui/drawing.ts
+++ b/src/widget/screenshot-ui/drawing.ts
@@ -1,6 +1,5 @@
 import Cairo from 'gi://cairo?version=1.0';
 import Gtk from 'gi://Gtk?version=4.0';
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../lib/hyprland';
 import type Screenshot from '../../lib/services/capture/screenshot';
 
@@ -87,7 +86,7 @@ export function draw(
     const sWin = selectedWindow;
     const winL = windows;
     const hyprland = getHyprland();
-    if (!hyprland) return null;
+    if (!hyprland) return;
 
     // ── Dim overlay ──────────────────────────────────────────
     cr.setSourceRGBA(DIM_COLOR.r, DIM_COLOR.g, DIM_COLOR.b, DIM_COLOR.a);

--- a/src/widget/screenshot-ui/index.tsx
+++ b/src/widget/screenshot-ui/index.tsx
@@ -1,7 +1,6 @@
 import Astal from 'gi://Astal?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
-import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import {getHyprland} from '../../lib/hyprland';
 import {bind, createState} from 'gnim';
 import {app} from '../../apps/shell/App';

--- a/src/widget/settings/index.tsx
+++ b/src/widget/settings/index.tsx
@@ -12,7 +12,7 @@ import Timer from './timer';
 import Debug from './debug';
 import {app} from '../../apps/shell/App';
 
-export const createSettingsWindow = (): any => {
+export const createSettingsWindow = (): Adw.PreferencesWindow => {
     return (
         <Adw.PreferencesWindow
             ref={self => WindowManager.get_default().setSettings(self)}
@@ -84,5 +84,5 @@ export const createSettingsWindow = (): any => {
                 <Debug />
             </Adw.PreferencesPage>
         </Adw.PreferencesWindow>
-    );
+    ) as unknown as Adw.PreferencesWindow;
 };


### PR DESCRIPTION
## What Changed

Post-migration lint and dead-code cleanup, stacked on `fix/post-migration-hardening` (review/merge the migration + hardening PRs first — diff shows only this 1 commit, 31 files):

- **17 stale imports removed** — leftovers from the `#/` alias era that became unused *because* the migration rewrote those call sites (8× `AstalHyprland`, 3× `Hyprland`, `Gio`, `GObject`, `effect`, `fmtOffset`, `captureMonitor`)
- **Stale type blocks/dead stores** — `AstalWl.WlDisplay` declaration in `env.d.ts` (code uses `AstalWl.Registry`), dead `localTz`/`tz` stores in bar clock, unused params, duplicated `appName || appName` fallback
- **Typing** — `any` → real types where safe (`eventBus` + killed `Function` types, `monitors`, `GreetSession`, `apRow`, settings window, `JSX.Element` node props); remaining load-bearing `any`s documented with `eslint-disable` (codebase convention)
- **Misc** — `consistent-return` in `draw()`, redundant `Anchor` alias, stale disable comment for an unloaded rule, prettier formatting

Result: **942 → 35 lint problems.** Remainders are intentional: 34× `sonarjs/public-static-readonly` (the lazy-singleton `static instance` idiom used app-wide — a rule-config decision, not cruft) + 1 documented TODO.

## Why

Migration-era debris makes future lint signal useless; this restores a trustworthy baseline.

## Risk Score

**1/5**

- Dead code deletion + type annotations only; no runtime behavior change (all tests + tsc confirm)
- Only functional tweaks: `return null` → `return` in `draw()` (void callback), dedup of identical `||` operands

## Type

- [x] chore / refactor

## Test Results

| Scenario | Status |
|----------|--------|
| `tsc --noEmit` | ✅ clean |
| Test suites (130 assertions) | ✅ all pass |
| `eslint` | ✅ 942 → 35 (intentional remainders) |
| `prettier --check` | ✅ clean |

## Checklist

- [x] Tests pass
- [x] Lint passes
- [x] Type-check passes
- [x] Risk score self-assessed
